### PR TITLE
Check Invalid LBA of Samsung SSD Read  Method

### DIFF
--- a/src/main/java/ssd/InvalidLBAExcpetion.java
+++ b/src/main/java/ssd/InvalidLBAExcpetion.java
@@ -1,0 +1,7 @@
+package ssd;
+
+public class InvalidLBAExcpetion extends RuntimeException {
+    public InvalidLBAExcpetion(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ssd/SSDInterface.java
+++ b/src/main/java/ssd/SSDInterface.java
@@ -1,6 +1,6 @@
 package ssd;
 
 public interface SSDInterface {
-    void read(String lba);
+    void read(String lba) throws InvalidLBAExcpetion;
     void write(String lba, String data);
 }

--- a/src/main/java/ssd/SamsungSSD.java
+++ b/src/main/java/ssd/SamsungSSD.java
@@ -5,6 +5,18 @@ public class SamsungSSD implements SSDInterface{
     @Override
     public void read(String lba) {
         //File Read
+        int lbaAddress = Integer.parseInt(lba);
+        checkInvalidLBAForRead(lbaAddress);
+    }
+
+    private void checkInvalidLBAForRead(int lbaAddress) {
+        if(isInvalidLBA(lbaAddress)){
+            throw new InvalidLBAExcpetion("LBA를 확인하세요 ");
+        }
+    }
+
+    private boolean isInvalidLBA(int lbaAddress) {
+        return lbaAddress < 0 || lbaAddress > 99;
     }
 
     @Override

--- a/src/test/java/ssd/SamsungSSDTest.java
+++ b/src/test/java/ssd/SamsungSSDTest.java
@@ -1,13 +1,33 @@
 package ssd;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(MockitoExtension.class)
 class SamsungSSDTest {
+
+    private SSDInterface ssdInterface;
+
+    @BeforeEach
+    void setUp() {
+        this.ssdInterface = new SamsungSSD();
+    }
+
+    @Test
+    void readInvalidArgumentTest(){
+        assertThrows(InvalidLBAExcpetion.class, ()->{
+           ssdInterface.read("-1");
+        });
+
+        assertThrows(InvalidLBAExcpetion.class, ()->{
+            ssdInterface.read("100");
+        });
+    }
+
     @Nested
     class SamsungSSDWrite {
         SamsungSSD ssd;


### PR DESCRIPTION
Read Command를 전달 받은 SamsungSSD Class에서
Read 가능한 LBA가 Argument로 전달되었는지 확인한다.
LBA 제한: 0 ~ 99