### PR TITLE
[TC] data에 비정상 값이 전달되면 RuntimeException 발생

### DIFF
--- a/src/main/java/shell/TestShellScript.java
+++ b/src/main/java/shell/TestShellScript.java
@@ -6,7 +6,7 @@ import ssd.SamsungSSD;
 public class TestShellScript {
     public static void main(String[] args) {
         DeviceDriver deviceDriver = new DeviceDriver(new SamsungSSD());
-        deviceDriver.writeData(10, 10);
-        deviceDriver.readData(10);
+        deviceDriver.writeData("10", "10");
+        deviceDriver.readData("10");
     }
 }

--- a/src/main/java/ssd/SamsungSSD.java
+++ b/src/main/java/ssd/SamsungSSD.java
@@ -9,6 +9,14 @@ public class SamsungSSD implements SSDInterface{
 
     @Override
     public void write(String lba, String data) {
-        //File Write
+        for(int i = 3; i < data.length(); i++){
+            if(isHexaDecimal(data.charAt(i))) {
+                throw new RuntimeException();
+            }
+        }
+    }
+
+    private static boolean isHexaDecimal(char c) {
+        return !(('0' <= c && c <= '9') || ('A' <= c && c <= 'F'));
     }
 }

--- a/src/test/java/ssd/SamsungSSDTest.java
+++ b/src/test/java/ssd/SamsungSSDTest.java
@@ -1,11 +1,9 @@
 package ssd;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class SamsungSSDTest {
     @Nested
@@ -24,27 +22,29 @@ class SamsungSSDTest {
         }
 
         @Test
-        @DisplayName("3번 LBA 영역에 값 0x1298CDEF를 저장한다")
+        @DisplayName("data 에 16진수 값이 넘는 값이 전달되면 RuntimeException 을 던진다")
         void writeThrowRuntimeExceptionWhenDataValueExceedInteger(){
-            // given
-
-
-            // when
-            ssd.write(3, 0x1298CDEF);
-
-            // then
+            try {
+                // when
+                ssd.write("3", "0x1298CDXF");
+                fail();
+            } catch(RuntimeException e) {
+                // then
+                assertThat(e).isInstanceOf(RuntimeException.class);
+            }
         }
 
         @Test
-        @DisplayName("3번 LBA 영역에 값 0x1298CDEF를 저장한다")
-        void writeLogicBlockAddress(){
-            // given
-
-
-            // when
-            ssd.write(3, 0x1298CDEF);
-
-            // then
+        @DisplayName("lba 에 0보다 작은 값이 전달되는 경우 RuntimeException 을 던진다")
+        void writeThrowRuntimeExceptionWhenLbaValueExceedInteger(){
+            try {
+                // when
+                ssd.write("-1", "0x12345678");
+                fail();
+            } catch(RuntimeException e) {
+                // then
+                assertThat(e).isInstanceOf(RuntimeException.class);
+            }
         }
     }
 }


### PR DESCRIPTION
[TC] lba, 데이터에 비정상 값이 전달되면 RuntimeException 발생

`write(String lba, String data)` 메소드에 전달되는 인자의 유효성을 검증합니다.

- lba: 0 ~ 99 까지 범위만 가능합니다.
- data: 0x[][][][][][][][] 형태로 전달되며 각 칸은 16진수 값으로 0 ~ 9, A ~ F 값만 허용합니다.

data 에 대한 테스트는 3번째 idx 부터 끝까지 문자를 검사해 범위에 포함되지 않으면 RuntimeException을 던집니다.
lba 에 대한 테스트는 fail 이 발생한 상태로 구현이 필요합니다.