### PR TITLE
TestShell help 메서드 추가

### DIFF
--- a/src/main/java/shell/TestShell.java
+++ b/src/main/java/shell/TestShell.java
@@ -61,7 +61,13 @@ public class TestShell {
     }
 
     public void help() {
-
+        System.out.println("Usage of TestShell");
+        System.out.println("write\t\twrite data at a LBA. ex) write [LBA] [Data]");
+        System.out.println("fullwrite\twrite data at all of LBA. ex) write [Data]");
+        System.out.println("read\t\tread data from a LBA. ex) read [LBA]");
+        System.out.println("fullread\tread data from all of LBA. ex) fullread");
+        System.out.println("help\t\tprint description of TestShell. ex) help");
+        System.out.println("exit\t\tend TestShell. ex) exit");
     }
 
     @VisibleForTesting

--- a/src/test/java/shell/TestShellTest.java
+++ b/src/test/java/shell/TestShellTest.java
@@ -11,7 +11,9 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import ssd.DeviceDriver;
 
+import java.io.ByteArrayOutputStream;
 import java.util.stream.Stream;
+import java.io.PrintStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -20,6 +22,13 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class TestShellTest {
+    public static final String HELP_DESCRIPTION = "Usage of TestShell\r\n"
+            + "write\t\twrite data at a LBA. ex) write [LBA] [Data]\r\n"
+            + "fullwrite\twrite data at all of LBA. ex) write [Data]\r\n"
+            + "read\t\tread data from a LBA. ex) read [LBA]\r\n"
+            + "fullread\tread data from all of LBA. ex) fullread\r\n"
+            + "help\t\tprint description of TestShell. ex) help\r\n"
+            + "exit\t\tend TestShell. ex) exit\r\n";
     @Spy
     TestShell spyTestShell;
 
@@ -74,6 +83,14 @@ class TestShellTest {
 
     @Test
     void help() {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(outputStream));
+
+        spyTestShell.help();
+
+        assertEquals(HELP_DESCRIPTION, outputStream.toString());
+        System.setOut(originalOut);
     }
 
     static Stream<Arguments> getLBAandDataList() {


### PR DESCRIPTION
help 메서드 추가했습니다.

Usage of TestShell
write		write data at a LBA. ex) write [LBA] [Data]
fullwrite	write data at all of LBA. ex) write [Data]
read		read data from a LBA. ex) read [LBA]
fullread	read data from all of LBA. ex) fullread
help		print description of TestShell. ex) help
exit		end TestShell. ex) exit