### PR TITLE
Add tests for print using files

### DIFF
--- a/src/main/java/shell/TestShell.java
+++ b/src/main/java/shell/TestShell.java
@@ -12,10 +12,11 @@ public class TestShell {
     // TODO
     // LBA 갯수는 DeviceDriver에서 가져오도록 고민
     public static final int NUMBER_OF_LBA = 100;
-    private static final String RESULT_FILE = "result.txt";
+    static final String RESULT_FILE = "result.txt";
     private DeviceDriver deviceDriver;
 
-    public TestShell() {}
+    public TestShell() {
+    }
 
     public TestShell(DeviceDriver deviceDriver) {
         setDeviceDriver(deviceDriver);

--- a/src/test/java/shell/TestShellTest.java
+++ b/src/test/java/shell/TestShellTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -36,6 +37,8 @@ class TestShellTest {
             + "fullread\tread data from all of LBA. ex) fullread\r\n"
             + "help\t\tprint description of TestShell. ex) help\r\n"
             + "exit\t\tend TestShell. ex) exit\r\n";
+    private static final String NOT_EXISTED_FILE = "not_existed_file.txt";
+
     @Spy
     TestShell spyTestShell;
 
@@ -99,12 +102,12 @@ class TestShellTest {
         verify(mockDeviceDriver, times(100)).readData(anyString());
     }
 
-    @Test
-    void printSuccess(@TempDir Path tempDir) throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = {"123", "aaa", "0xFF"})
+    void printSuccess(String input, @TempDir Path tempDir) throws IOException {
         Path filePath = tempDir.resolve(RESULT_FILE);
         Files.createFile(filePath);
 
-        String input = "123";
         Files.write(filePath, input.getBytes());
 
         spyTestShell.print(filePath.toString());
@@ -115,12 +118,10 @@ class TestShellTest {
 
     @Test
     void printFail() {
-        String file = "not_existed_file.txt";
-
-        spyTestShell.print(file);
+        spyTestShell.print(NOT_EXISTED_FILE);
 
         String actual = outputStream.toString().trim();
-        String expected = "Failed to read result. " + file;
+        String expected = "Failed to read result. " + NOT_EXISTED_FILE;
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -131,8 +132,6 @@ class TestShellTest {
 
     @Test
     void help() {
-
-
         spyTestShell.help();
 
         assertEquals(HELP_DESCRIPTION, outputStream.toString());


### PR DESCRIPTION
파일을 읽어 출력하는 메서드에 대한 테스트 커버리지 확보
- TempDir을 활용하여 임시 파일 생성 후 내용 비교