### PR TITLE
fix: print error when invalid read occurs

### DIFF
--- a/src/main/java/shell/TestShell.java
+++ b/src/main/java/shell/TestShell.java
@@ -1,6 +1,7 @@
 package shell;
 
 
+import org.assertj.core.util.Strings;
 import org.assertj.core.util.VisibleForTesting;
 
 import java.io.IOException;
@@ -106,7 +107,13 @@ public class TestShell {
             return;
         }
 
-        System.out.println(read(arguments));
+        String result = read(arguments);
+
+        if (!Strings.isNullOrEmpty(result)) {
+            System.out.println(result);
+        } else {
+            System.out.println("Read Error");
+        }
     }
 
     public ArrayList<String> fullread(String[] arguments) {


### PR DESCRIPTION
- read에 대한 잘못된 lba 값인 경우, result.txt에는 빈 값이 쓰여질 것이고 이 때는 read error 출력
- ex) read -1