### PR TITLE
[HOT FIX] Read 명령어에서 Invalid Argument 가 전달되는 경우 result.txt 에 빈 문자열을 넣는다

### DIFF
--- a/src/main/java/ssd/SamsungSSD.java
+++ b/src/main/java/ssd/SamsungSSD.java
@@ -13,6 +13,7 @@ public class SamsungSSD implements SSDInterface{
 
     public SamsungSSD() {
         createNandTextFile();
+        initResultFile();
     }
 
     private void createNandTextFile() {
@@ -42,6 +43,10 @@ public class SamsungSSD implements SSDInterface{
         } catch (IOException e) {
             System.out.println("파일을 생성하는 도중 오류가 발생했습니다.");
         }
+    }
+
+    private void initResultFile() {
+        writeResultFile("");
     }
 
     @Override


### PR DESCRIPTION
## [HOT FIX] Read 명령어에서 Invalid Argument 가 발생한 경우 result.txt 에 빈 문자열 삽입

### 변경점

SamsungSSD 클래스 생성자에 result.txt 초기화 로직 삽입.